### PR TITLE
query keyboard LED status via X11 C API

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,6 +47,14 @@ CFLAGS+=$(shell pkg-config ncurses --cflags)
 LDLIBS+=$(shell pkg-config ncurses --libs)
 endif
 
+# X11 library is required to determine keyboard LED status in an X terminal.
+ifdef ROGUE_NO_X11
+CFLAGS+=-DROGUE_NO_X11
+else
+CFLAGS+=$(shell pkg-config x11 --cflags)
+LDLIBS+=$(shell pkg-config x11 --libs)
+endif
+
 export CFLAGS
 
 OBJS=armor.o new_leve.o command.o mach_dep.o rip.o save.o \

--- a/src/mach_dep.c
+++ b/src/mach_dep.c
@@ -13,7 +13,7 @@
 /*@
  * Pointer to X display, if running under X.  Used to query keyboard LED status.
  */
-Display *xdisplay;
+Display *xdisplay = NULL;
 #endif
 
 #ifdef ROGUE_DOS_CLOCK
@@ -849,7 +849,10 @@ unsetup()
 	set_ctrlb(ocb);
 #ifndef ROGUE_NO_X11
 	if (xdisplay)
+	{
 		XCloseDisplay(xdisplay);
+		xdisplay = NULL;
+	}
 #endif
 }
 


### PR DESCRIPTION
Executing xset on every tick is a rather expensive operation, as it has to
spawn a new process and open and close a TCP connection each time, slowing the
game down significantly.  Additionally, if $DISPLAY is set but no X server is
present, error messages appear continuously and make the game unplayable.

To resolve this, we can use the X11 C API to open an X display connection on
startup, and keep it open for the duration of the game.  Then the keyboard LED
status can be queried directly via XGetKeyboardControl().  With PuTTY, if X11
forwarding is enabled ($DISPLAY is set) but no X server is running on the
client, this still results in a single error message on startup, but it quickly
disappears after raise_curtain().

Still, it seems `vcxsrv` does not report the keyboard LED status, and I think reading LEDs from `/dev/tty` will not work on any SSH connection, so Fast Mode is still unavailable.  Maybe this needs an alternative key binding.