### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/fight.c
+++ b/src/fight.c
@@ -292,7 +292,7 @@ check_level(void)
 		max_hp += add;
 		if ((pstats.s_hpt += add) > max_hp)
 			pstats.s_hpt = max_hp;
-			msg("and achieve the rank of \"%s\"", he_man[i-1]);
+		msg("and achieve the rank of \"%s\"", he_man[i-1]);
 	}
 }
 

--- a/src/rip.c
+++ b/src/rip.c
@@ -160,50 +160,50 @@ pr_scores(int newrank, struct sc_ent *top10)
 			else
 				yellow();
 		}
-	if (top10->sc_gold <=0 )
-		break;
-	curl = 4 + ((COLS==40)?(i * 2):i);
-	move (curl,0);
-	printw("%d ",top10->sc_gold);
-	move (curl,6);
-	if (newrank - 1 != i)
-		red();
-	printw("%s",top10->sc_name);
-	if ((newrank) - 1 != i)
-		brown();
-	if (top10->sc_level >= 26)  //@ There is AMULETLEVEL, you know?
-		altmsg = " Honored by the Guild";
+		if (top10->sc_gold <=0 )
+			break;
+		curl = 4 + ((COLS==40)?(i * 2):i);
+		move (curl,0);
+		printw("%d ",top10->sc_gold);
+		move (curl,6);
+		if (newrank - 1 != i)
+			red();
+		printw("%s",top10->sc_name);
+		if ((newrank) - 1 != i)
+			brown();
+		if (top10->sc_level >= 26)  //@ There is AMULETLEVEL, you know?
+			altmsg = " Honored by the Guild";
 
-	if (is_alpha(top10->sc_fate))
-	{
-		sprintf(dthstr," killed by %s",
-				killname((0xff & top10->sc_fate), TRUE));
-		if (COLS == 40 && strlen(dthstr) > 23)
-			strcpy(dthstr," killed");
-	}
-	else
-	{
-		switch(top10->sc_fate)
+		if (is_alpha(top10->sc_fate))
 		{
-			case 2:
-				altmsg = " A total winner!";
-				break;
-			case 1:
-				strcpy(dthstr," quit");
-				break;
-			default:
-				strcpy(dthstr," wierded out");
-				break;
+			sprintf(dthstr," killed by %s",
+				killname((0xff & top10->sc_fate), TRUE));
+			if (COLS == 40 && strlen(dthstr) > 23)
+				strcpy(dthstr," killed");
 		}
-	}
-	if ((signed)(strlen(top10->sc_name) + 10 +
-		strlen(he_man[top10->sc_rank-1])) < COLS)
-	{
-		if (top10->sc_rank > 1 && (strlen(top10->sc_name)))
-			printw(" \"%s\"",he_man[top10->sc_rank - 1]);
-	}
-	if (COLS == 40)
-		move(curl+1,6);
+		else
+		{
+			switch(top10->sc_fate)
+			{
+				case 2:
+					altmsg = " A total winner!";
+					break;
+				case 1:
+					strcpy(dthstr," quit");
+					break;
+				default:
+					strcpy(dthstr," wierded out");
+					break;
+			}
+		}
+		if ((signed)(strlen(top10->sc_name) + 10 +
+			strlen(he_man[top10->sc_rank-1])) < COLS)
+		{
+			if (top10->sc_rank > 1 && (strlen(top10->sc_name)))
+				printw(" \"%s\"",he_man[top10->sc_rank - 1]);
+		}
+		if (COLS == 40)
+			move(curl+1,6);
 		if (altmsg == NULL)
 			printw("%s on level %d",dthstr,top10->sc_level);
 		else

--- a/src/things.c
+++ b/src/things.c
@@ -578,7 +578,7 @@ nothing(byte type)
 		when SCROLL: tystr = "scroll";
 		when RING: tystr = "ring";
 		when STICK: tystr = "stick";
-		break;
+		otherwise: tystr = NULL; //@ silence maybe-uninitialized warning
 	}
 	sprintf(sp, " about any %ss", tystr);
 	return prbuf;


### PR DESCRIPTION
GCC 11 makes the following complaints:
```
rip.c: In function ‘pr_scores’:
rip.c:205:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  205 |         if (COLS == 40)
      |         ^~
rip.c:207:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  207 |                 if (altmsg == NULL)
      |                 ^~
```
```
fight.c: In function ‘check_level’:
fight.c:293:17: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  293 |                 if ((pstats.s_hpt += add) > max_hp)
      |                 ^~
fight.c:295:25: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  295 |                         msg("and achieve the rank of \"%s\"", he_man[i-1]);
      |                         ^~~
```
```
things.c: In function ‘nothing’:
things.c:583:9: warning: ‘tystr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  583 |         sprintf(sp, " about any %ss", tystr);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The first two are clearly cases of mixed indentation, easy to fix.
For the latter one I used the weird `otherwise` macro from `rogue.h` to be consistent with the surrounding code.  I don't know if that's something to be encouraged.
