### PR TITLE
Fix bug in Vorpalize scroll

### DIFF
--- a/src/monsters.c
+++ b/src/monsters.c
@@ -13,6 +13,20 @@ static int	exp_add(THING *tp);
  * List of monsters in rough order of vorpalness
  */
 
+/*@
+ * Note:  vorp_mons was not present in the original v1.48 code.  It is used to
+ * select a target for the Vorpalize Weapon scroll.
+ * Previously, lvl_mons was used, which contains spaces.  When a space
+ * character was selected, identifying the player's weapon then indexed the
+ * monsters array out-of-bounds, causing a segfault.
+ *
+ * From disassembling earlier Rogue PC versions, we can deduce that lvl_mons
+ * originally had no spaces when the Vorpalize scroll was introduced, so
+ * re-introducing this string with no spaces is believed to reproduce the
+ * intended behavior.
+ */
+
+static char *vorp_mons = "KEBHISORZLCAQNYTWFPUGMXVJD";
 static char *lvl_mons =  "K BHISOR LCA NYTWFP GMXVJD";
 static char *wand_mons = "KEBHISORZ CAQ YTW PUGM VJ ";
 
@@ -231,15 +245,18 @@ give_pack(tp)
 /*
  * pick_mons:
  *	Choose a sort of monster for the enemy of a vorpally enchanted weapon
+ *
+ *	@ Fixed:  lvl_mons renamed to vorp_mons, to prevent this function from
+ *	  returning space characters.  See comment for vorp_mons above.
  */
 char
 pick_mons(void)
 {
-	register char *cp = lvl_mons + strlen(lvl_mons);
+	register char *cp = vorp_mons + strlen(vorp_mons);
 
-	while (--cp >= lvl_mons && rnd(10))
+	while (--cp >= vorp_mons && rnd(10))
 		;
-	if (cp < lvl_mons)
+	if (cp < vorp_mons)
 		return 'M';
 	return *cp;
 }


### PR DESCRIPTION
The Vorpalize scroll enchants a weapon to do more damage to a specific type of monster.  This monster is randomly picked in `pick_mons()` from the string `lvl_mons`.

Problem is, this string contains spaces, and sometimes (surprisingly often) it lands on one.  Identification then causes an out-of-bounds access on the monster name array.  In the original version, this just results in a garbled name:

![IMG_0287y](https://user-images.githubusercontent.com/5897442/131058770-9767fcbd-138f-4b31-a9af-dd3348d39cd9.jpg)

On modern systems however, we get a segmentation fault.

This patch resolves the issue by skipping over spaces.  Evaluation order could change the mechanics slightly, `(*cp == ' ' || rnd(10))` vs `(rnd(10) || *cp == ' ')`.  I think the former increases the probability of selecting a higher level monster.

In case this behaviour was actually intentional (i.e., it should be possible for vorpalize to *partially* fail), then `pick_mons()` should return 0 instead when it lands on a space.  The weapon still receives a +1,+1 boost, and it is then possible to use a second vorp scroll on the same weapon.  Personally I doubt the scroll was intended to work this way.
